### PR TITLE
bug: reduce rpc calls

### DIFF
--- a/src/app/providers/default-provider.service.ts
+++ b/src/app/providers/default-provider.service.ts
@@ -7,10 +7,11 @@ import { environment } from 'src/environments/environment';
 })
 export class DefaultProviderService {
 
-  provider: ethers.providers.JsonRpcProvider
+  provider: ethers.providers.StaticJsonRpcProvider
 
   constructor() {
-    this.provider = new ethers.providers.JsonRpcProvider(environment.jsonRpcUrl);
+    this.provider = new ethers.providers.StaticJsonRpcProvider(environment.jsonRpcUrl);
+    this.provider.pollingInterval = 20000;
   }
 
   async getBlockNumber() {


### PR DESCRIPTION
**Problem**
Currently the app makes too many requests and we hare hitting limits on Infura. Find a way to streamline these requests to reduce the number of calls

**Changes**
- Increased polling interval to 20 seconds.
- Changed `jsonRpcProvider` to `StaticJsonRpcProvider` to get rid of `eth_chainId` calls.

**Test**
- Changes were tested locally in the UI. No breaking changes detected.