### PR TITLE
fix: navigate to markets when network change

### DIFF
--- a/src/app/borrow/pages/borrow-landing/borrow-landing.page.ts
+++ b/src/app/borrow/pages/borrow-landing/borrow-landing.page.ts
@@ -59,7 +59,7 @@ export class BorrowLandingPage implements OnInit, OnDestroy {
     })
 
     this.netWorkChangeSubscription = this.environmentService.environmentSubject.subscribe(async network => {
-      if(network && (network !== this.environmentService.environment)){
+      if(network){
         await this.vaultStatsService.loadVaultStats();
       }
     })

--- a/src/app/borrow/pages/pool/borrow-pool-details/borrow-pool-details.page.ts
+++ b/src/app/borrow/pages/pool/borrow-pool-details/borrow-pool-details.page.ts
@@ -560,9 +560,9 @@ export class BorrowPoolDetailsPage implements OnInit, OnDestroy {
     });
 
     this.netWorkChangeSubscription = this.environmentService.environmentSubject.subscribe(async network => {
-      if(network && (network !== this.environmentService.environment)){
+      const chainId = await (window as any).ethereum.request({ method: 'eth_chainId' });
+      if(network && (network.config.networkParams.chainId.toLocaleLowerCase() !== chainId)){
         this.navigateBack();
-        return
       }
     })
   }

--- a/src/app/lend/pages/pool/lend-pool-details/lend-pool-details.page.ts
+++ b/src/app/lend/pages/pool/lend-pool-details/lend-pool-details.page.ts
@@ -223,7 +223,8 @@ export class LendPoolDetailsPage implements OnInit, OnDestroy {
     })
 
     this.netWorkChangeSubscription = this.environmentService.environmentSubject.subscribe(async network => {
-      if(network && (network !== this.environmentService.environment)){
+      const chainId = await (window as any).ethereum.request({ method: 'eth_chainId' });
+      if(network && (network.config.networkParams.chainId.toLocaleLowerCase() !== chainId)){
         this.navigateBack();
       }
     })


### PR DESCRIPTION
## Description
Whenever a user switches networks while being in a specific pool, the pool becomes inactive as it is unsupported by the new network. To resolve this, we should navigate back to the markets where the supported pools are shown.

## Changes
- Implement navigation to the markets displaying supported pools whenever a network change occurs.

## Testing
- No breaking changes
